### PR TITLE
techdebt: fix disconnect behavior revert

### DIFF
--- a/BRPeerManager.h
+++ b/BRPeerManager.h
@@ -66,9 +66,7 @@ void BRPeerManagerSetCallbacks(BRPeerManager *manager, void *info,
                                void (*saveBlocks)(void *info, int replace, BRMerkleBlock *blocks[], size_t blocksCount),
                                void (*savePeers)(void *info, int replace, const BRPeer peers[], size_t peersCount),
                                int (*networkIsReachable)(void *info),
-                               void (*threadCleanup)(void *info),
-                               int (*isFeatureSelectedPeersOn)(void *info),
-                               char **(*fetchSelectedPeers)(void *info));
+                               void (*threadCleanup)(void *info));
 
 // specifies a single fixed peer to use when connecting to the bitcoin network
 // set address to UINT128_ZERO to revert to default behavior


### PR DESCRIPTION
# Why?
While we saw some good progress in the core library in syncing, there were some changes that require the native clients to change (Android and iOS).  We are in the stage where it is better that the core lib provide consistent behavior for any platform so this PR is a rollback to the fix (disconnect error).

## Result
Re-added @andhikayuana fix on the thread blocking