### PR TITLE
Changes to meet iOS 18.4.1 linking requirements

### DIFF
--- a/BRPeer.h
+++ b/BRPeer.h
@@ -37,10 +37,12 @@
 #define _va_first(first, ...) first
 #define _va_rest(first, ...) __VA_ARGS__
 
-#if defined(TARGET_OS_MAC)
-#include <Foundation/Foundation.h>
-#define _peer_log(...) NSLog(__VA_ARGS__)
-#elif defined(__ANDROID__)
+    // NERFED iOS Logs: With iOS 18.4.1, the Modulemap causes conflicts and causes Xcode to not compile for the Foundation.h import
+    // 
+    // #if defined(TARGET_OS_MAC)
+    // #include <Foundation/Foundation.h>
+    // #define _peer_log(...) NSLog(__VA_ARGS__)
+#if defined(__ANDROID__)
 #include <android/log.h>
 #define _peer_log(...) __android_log_print(ANDROID_LOG_INFO, "bread", __VA_ARGS__)
 #else

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
-# breadwallet-core
-SPV bitcoin C library
+# core
+SPV Litecoin wallet C library
 
-[getting started](https://github.com/breadwallet/breadwallet-core/wiki)
+We have taken the breadwallet-core library and made changes to make it better for SPV clients like [Brainwallet](https://www.brainwallet.co)
+We reconize that there are other more modern libraries but the existing user base means we intend to fully optimize this library and use it to its full potential
+
+
+## secp256k1
+We leverage [secp256k1](https://github.com/bitcoin-core/secp256k1) @ b408c6a because this commit was the last one the Bitcoin devs used with a config file. We may update this at some point.
+
+## Releases
+Current: v10.0.0
+
+## Contact
+kerry@grunt.ltd
+---
+[Legacy getting started](https://github.com/breadwallet/breadwallet-core/wiki)

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,10 @@
 module BRCore [system] [extern_c] {
+    
+    //--Added after iOS 18.4.1--//
+    link Foundation
+    requires objc
+    //--Added after iOS 18.4.1--//
+       
     textual header "secp256k1/src/basic-config.h"
     textual header "secp256k1/src/secp256k1.c"
     header "BRInt.h"


### PR DESCRIPTION
# Fix
The iOS 18.4.1 the modulemap and lookup breaks. This fix allow that to happens and removes the logs which are not important and chatty.